### PR TITLE
Catch missing on getToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Forked from https://github.com/XoddX/heatzy
+
 # heatzy
 
 A module for interacting with Heatzy devices

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Forked from https://github.com/XoddX/heatzy
-
 # heatzy
 
 A module for interacting with Heatzy devices

--- a/index.js
+++ b/index.js
@@ -273,7 +273,9 @@ class Heatzy {
             this.token = body.token;
             this.tokenExpires = body.expire_at;
             return body.token;
-        })
+        }).catch((error) => {
+            return error; 
+        });
     }
 
     getDevices() {


### PR DESCRIPTION
Hi there,

I created a pull request in order to suppress the following warning when using the heatzy package:

`
(node:12886) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:12886) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
`